### PR TITLE
chore: Fix typo in i18n `zh-Hans`

### DIFF
--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -1,5 +1,5 @@
 {
-  "imgtag-desc": "允许在高版本 MediaWiki 中安全的插入 <code>&lt;img&gt;</code> 标签。",
+  "imgtag-desc": "允许在高版本 MediaWiki 中安全地插入 <code>&lt;img&gt;</code> 标签。",
   "imgtag-invalid": "插入 <code>&lt;img&gt;</code> 时出现问题{{#if: $1 |：$1 | 请检查参数。 }}",
   "imgtag-empty-src": "未设置 <code>src</code> 属性。",
   "imgtag-invalid-src": "无效的 <code>src</code> 属性",


### PR DESCRIPTION
我是“的”“地”“得”警察。

## Sourcery 总结

杂项任务:
- 修正了 `i18n/zh-hans.json` 翻译条目中的一个拼写错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Correct a typo in the `i18n/zh-hans.json` translation entry.

</details>